### PR TITLE
Update New-RsRestFolder.ps1

### DIFF
--- a/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestFolder.ps1
+++ b/ReportingServicesTools/Functions/CatalogItems/Rest/New-RsRestFolder.ps1
@@ -29,7 +29,7 @@ function New-RsRestFolder
             Specify the session to be used when making calls to REST Endpoint.
 
         .EXAMPLE
-            New-RsRestFolder -RsFolder MyNewFolder -RsFolder /
+            New-RsRestFolder -FolderName MyNewFolder -RsFolder /
 
             Description
             -----------


### PR DESCRIPTION
Fixes #259 .

Changes proposed in this pull request:
 - Fixes the New-RsRestFolder example to use the -FolderName parameter instead of listing -RsFolder twice

How to test this code:
 - `Get-Help New-RsRestFolder -examples` should list the new example
 - Running the new example `New-RsRestFolder -FolderName MyNewFolder -RsFolder /` should create a new folder 'MyNewFolder' in the parent directory
 
Has been tested on:
 - Powershell 3 and above
 - Windows 7 and above
 - SQL Server 2012 and above
